### PR TITLE
Pkg resource fix3.12

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,2 @@
-[bumpversion]
-current_version = 2.0.0
-
 [aliases]
 test = pytest

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ requirements = (
     'Pillow',
     'pytesseract',
     'requests',
+    'setuptools',
 )
 
 dev_requirements = (
@@ -17,7 +18,7 @@ dev_requirements = (
 
 setup(
     name='pytextractor',
-    version='2.0.0',
+    version='2.1.0',
     author='danny crasto',
     author_email='danwald79@gmail.com',
     description='text extractor from images',
@@ -26,10 +27,10 @@ setup(
     url='https://github.com/danwald/pytextractor/',
     packages=find_packages(),
     install_requires=requirements,
+    tests_require=dev_requirements,
     extras_require={"dev": dev_requirements},
     use_scm_version=True,
     setup_requires=['pytest-runner', 'setuptools_scm', ],
-    tests_require=['pytest', ],
     license='MIT',
     include_package_data=False,
     entry_points={'console_scripts': ['text_detector=pytextractor.text_detection:text_detector']},
@@ -40,6 +41,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'License :: OSI Approved :: MIT License',
     ],
 )


### PR DESCRIPTION
[setuptools isn't included by default after 3.11](https://docs.python.org/3/whatsnew/3.12.html)

- This explicitly adds it as a dependency to fix issue #15 and support py3.12. 
- removes bump2version config